### PR TITLE
Wechsel von Select zu SelectVariable

### DIFF
--- a/CSVZipExport/form.json
+++ b/CSVZipExport/form.json
@@ -132,8 +132,7 @@
                     "value": 3
                 }
             ],
-            "name": "MailInterval",
-            "width": "700px"
+            "name": "MailInterval"
         },
         {
             "type": "SelectTime",

--- a/CSVZipExport/form.json
+++ b/CSVZipExport/form.json
@@ -7,21 +7,23 @@
                     "type": "ValidationTextBox",
                     "caption": "Filter",
                     "name": "Filter",
-                    "width": "500px"
+                    "width": "550px"
                 },
                 {
                     "type": "Button",
                     "caption": "Apply Filter",
                     "onClick": "CSV_UpdateFilter($id, $Filter);"
                 }
-            ]
+            ],
+            "visible": false
         },
         {
-            "type": "Select",
+            "type": "SelectVariable",
             "caption": "Logged Variables",
             "options": [],
             "name": "ArchiveVariable",
-            "width": "700px"
+            "width": "700px",
+            "requiredLogging": 1
         },
         {
             "type": "SelectDateTime",

--- a/CSVZipExport/locale.json
+++ b/CSVZipExport/locale.json
@@ -24,7 +24,8 @@
             "Enable sending of cyclic mails": "Zyklisches senden aktivieren",
             "Summary of %s (%s to %s)": "Zusammenfassung von %s (%s bis %s)",
             "In the appendix you can find the created CSV-File.": "Im Anhang finden Sie die erstellte CSV-Datei.",
-            "The selected SMTP-Instance doesn't exist": "Die ausgewählte SMTP-Instanz existiert nicht"
+            "The selected SMTP-Instance doesn't exist": "Die ausgewählte SMTP-Instanz existiert nicht",
+            "Variable is not selected": "Variable ist nicht ausgewählt"
         }
     }
 }

--- a/CSVZipExport/module.php
+++ b/CSVZipExport/module.php
@@ -74,13 +74,15 @@ class CSVZipExport extends IPSModule
 
     public function UserExport(int $ArchiveVariable, int $AggregationStage, string $AggregationStart, string $AggregationEnd)
     {
+        if (!IPS_VariableExists($ArchiveVariable)) {
+            return 'javascript:alert("' . $this->Translate('Variable is not selected') . ' ");';
+        }
         $this->UpdateFormField('ExportBar', 'visible', true);
         $relativePath = $this->Export($ArchiveVariable, $AggregationStage, $AggregationStart, $AggregationEnd);
         sleep(1);
         $this->UpdateFormField('ExportBar', 'visible', false);
         //Reset ZipDeleteTimer
         $this->SetTimerInterval('DeleteZipTimer', 1000 * 60 * 60);
-
         return $relativePath;
     }
 
@@ -148,6 +150,10 @@ class CSVZipExport extends IPSModule
     public function SendMail()
     {
         $archiveVariable = $this->ReadPropertyInteger('ArchiveVariable');
+        if (!IPS_VariableExists($archiveVariable)) {
+            echo $this->Translate('Variable is not selected');
+            return;
+        }
         $aggregationStage = $this->ReadPropertyInteger('AggregationStage');
         $aggregationStart = $this->ReadPropertyString('AggregationStart');
         $aggregationEnd = $this->ReadPropertyString('AggregationEnd');

--- a/CSVZipExport/module.php
+++ b/CSVZipExport/module.php
@@ -60,10 +60,13 @@ class CSVZipExport extends IPSModule
             'minute' => 59,
             'second' => 59
         ];
+
+        //If the module "SyncMySQL" is install, get other options
         if (IPS_ModuleExists('{7E122824-E4D6-4FF8-8AA1-2B7BB36D5EC9}')) {
             $jsonForm['elements'][0]['visible'] = true;
             $jsonForm['elements'][1]['type'] = 'Select';
             $jsonForm['elements'][1]['options'] = $this->GetOptions();
+            unset($jsonForm['elements'][1]['requiredLogging']);
         }
 
         return json_encode($jsonForm);

--- a/CSVZipExport/module.php
+++ b/CSVZipExport/module.php
@@ -60,7 +60,12 @@ class CSVZipExport extends IPSModule
             'minute' => 59,
             'second' => 59
         ];
-        $jsonForm['elements'][1]['options'] = $this->GetOptions();
+        if (IPS_ModuleExists('{7E122824-E4D6-4FF8-8AA1-2B7BB36D5EC9}')) {
+            $jsonForm['elements'][0]['visible'] = true;
+            $jsonForm['elements'][1]['type'] = 'Select';
+            $jsonForm['elements'][1]['options'] = $this->GetOptions();
+        }
+
         return json_encode($jsonForm);
     }
 


### PR DESCRIPTION
Da der Standard für die Variablenauswahl "SelectVariable" ist wurde das Konfigurationsfeld von "Select" zu "SelectVariable" gewechselt und das Feld Filter erstmal ausgeblendet. Um die Funktionalität für den Ursprünglichen Auftraggeber mit dem Modul "SyncMySQL" zu behalten, wird das Feld "Select" und "Filter" trotzdem angezeigt, wenn das Modul installiert ist. 