### PR TITLE
Mehr als 10000 Werte als Archivwerte bekommen 

### DIFF
--- a/CSVZipExport/README.md
+++ b/CSVZipExport/README.md
@@ -73,7 +73,7 @@ Beispiel:
 
 
 `void CSV_SendMail(integer $InstanzID);`
-Senden durch eine SMTP Instaz eine Mail mit einer erzeugten Zip-Datei
+Senden durch eine SMTP Instanz eine Mail mit einer erzeugten Zip-Datei
 
 Beispiel:
 `CSV_SendMail(12345);`


### PR DESCRIPTION
Wenn der Zeitraum im Archiv mehr als 10000 Werte enthält, werden diese nun fortwährend ausgelesen. Vorher wurden diese abgeschnitten.

close symcon/modules/issues/254